### PR TITLE
Avoid infinite loop when repeated scene chosen

### DIFF
--- a/SnowFlakeFirmware/src/Application.cpp
+++ b/SnowFlakeFirmware/src/Application.cpp
@@ -100,7 +100,7 @@ void loop()
 		if ((systemTime - gLastSceneBlend) >= cSceneDuration && cScenesOnDisplayCount > 1) {
 			auto nextScene = Helper::getRandom8(0, cScenesOnDisplayCount-1);
 			while (nextScene == gCurrentSceneIndex) {
-				Helper::getRandom8(0, cScenesOnDisplayCount-1);
+				nextScene = Helper::getRandom8(0, cScenesOnDisplayCount-1);
 			}
 			gCurrentSceneIndex = nextScene;
 			Player::blendToScene(cScenesOnDisplay[gCurrentSceneIndex], cBlendDuration);


### PR DESCRIPTION
Had a quick gdb session and found that if the random scene chosen is the same as the current scene, it gets stuck in here - it's missing the assignment. :)